### PR TITLE
Fix github publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,22 +10,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.release.target_commitish }}
     - name: Use Node.js 14
       uses: actions/setup-node@v1
       with:
         node-version: 14
         registry-url: https://registry.npmjs.org/
-    - run: npm ci
-    - run: git config --global user.name "KinderGouello"
-    - run: git config --global user.email "rigouello@gmail.com"
-    - run: npm version ${{ github.event.release.tag_name }}
     - run: npm run build
-    - run: npm test
-    - run: npm publish --tag ${{ github.event.release.target_commitish }}
+    - run: npm ci
+    - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - run: git push
-      env:
-        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Remove the push to update package version in master because the branch is protected. Also, update the `npm publish` command to publish the latest instead